### PR TITLE
Fix warning in mbf_recovery_behaviors

### DIFF
--- a/moveback_recovery/src/moveback_recovery.cpp
+++ b/moveback_recovery/src/moveback_recovery.cpp
@@ -287,6 +287,7 @@ uint32_t MoveBackRecovery::publishStop() const
   zero_vel.linear.x = zero_vel.linear.y = zero_vel.linear.z = 0;
   zero_vel.angular.x = zero_vel.angular.y = zero_vel.angular.z = 0;
   cmd_vel_pub_.publish(zero_vel);
+  return 0;
 }
 
 bool MoveBackRecovery::cancel() {


### PR DESCRIPTION
https://app.clickup.com/t/86c4ckqzw

```
/home/navflex/catkin_ws/src/mbf_recovery_behaviors/moveback_recovery/src/moveback_recovery.cpp: In member function ‘uint32_t moveback_recovery::MoveBackRecovery::publishStop() const’:
/home/navflex/catkin_ws/src/mbf_recovery_behaviors/moveback_recovery/src/moveback_recovery.cpp:290:1: warning: no return statement in function returning non-void [-Wreturn-type]
  290 | }
      | ^
```