### PR TITLE
build: silence CMP0048 + fix -Wreturn-type warning in mbf_recovery_behaviors

### DIFF
--- a/mbf_recovery_behaviors/CMakeLists.txt
+++ b/mbf_recovery_behaviors/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(mbf_recovery_behaviors)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/mbf_recovery_behaviors/CMakeLists.txt
+++ b/mbf_recovery_behaviors/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(mbf_recovery_behaviors)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/moveback_recovery/CMakeLists.txt
+++ b/moveback_recovery/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(moveback_recovery)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/moveback_recovery/CMakeLists.txt
+++ b/moveback_recovery/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(moveback_recovery)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/moveback_recovery/src/moveback_recovery.cpp
+++ b/moveback_recovery/src/moveback_recovery.cpp
@@ -287,6 +287,7 @@ uint32_t MoveBackRecovery::publishStop() const
   zero_vel.linear.x = zero_vel.linear.y = zero_vel.linear.z = 0;
   zero_vel.angular.x = zero_vel.angular.y = zero_vel.angular.z = 0;
   cmd_vel_pub_.publish(zero_vel);
+  return 0;
 }
 
 bool MoveBackRecovery::cancel() {


### PR DESCRIPTION
[ClickUp ticket](https://app.clickup.com/t/2157606/86cakky7u)

## What & why

Two build-warning cleanups for `mbf_recovery_behaviors`, originally pushed directly to `master`; re-landed here as a PR. Build-system hygiene plus one latent-undefined-behavior fix. No behavioral change to the recovery logic.

## Changes

### 1. `cmake_minimum_required(VERSION 2.8.3 → 3.16)` — both packages
Applied to `mbf_recovery_behaviors/CMakeLists.txt` and `moveback_recovery/CMakeLists.txt`. The pre-3.0 floor left policy **CMP0048** unset → CMake warned on every `project()`. Raising the minimum to **3.16** (matching the toolchain — the Noetic container ships CMake **3.16.3**) sets CMP0048 and every policy through 3.16 to **NEW**, clearing the warning and moving off the deprecated OLD defaults. Neither package reads `PROJECT_VERSION` (versions come from `package.xml`), so the bump is inert beyond policy defaults. Landed in two steps: `f8764fb` → 3.0.2, then `4587c5f` → 3.16 to match the workspace-wide floor.

### 2. `-Wreturn-type` in `MoveBackRecovery::publishStop()`  (`86eda08`)
`uint32_t MoveBackRecovery::publishStop() const` reached the end of the function without returning a value — a compiler warning (*control reaches end of non-void function*) and **latent undefined behavior** (the returned status code was whatever was in the register). Added `return 0;`.

Safe: `publishStop()` returns a status/outcome code, `0` is the success/`OK` convention in the recovery-behavior API, and the prior behavior was UB — so this silences the warning and makes the return value deterministic.

## Verification
- `catkin build mbf_recovery_behaviors` (both packages) configures and compiles with **no** CMP0048 and **no** `-Wreturn-type` warnings.
- No change to recovery-behavior logic or public interfaces.

## Commits
- `86eda08` — fix `-Wreturn-type` in `publishStop()` (`return 0;`)
- `f8764fb` — bump `cmake_minimum_required` (→ 3.0.2)
- `4587c5f` — raise `cmake_minimum_required` to **3.16** (workspace-wide floor)
