### PR TITLE
chore: add COLCON_IGNORE (shared ~/code single-tree workspace)

### DIFF
--- a/COLCON_IGNORE
+++ b/COLCON_IGNORE
@@ -1,0 +1,1 @@
+ROS1-only tree: colcon must skip it in the shared ~/code workspace. Remove when the ROS2 port / dual structure lands.


### PR DESCRIPTION
###### ClickUp Ticket Link
https://app.clickup.com/t/2157606/86cbe1paq

One-line marker for the single-tree migration (orchestra `sync ros2/migration` → flat `~/code` mounted into both ROS1 and ROS2 containers): ROS1-only tree: colcon must skip it in the shared ~/code workspace. Remove when the ROS2 port / dual structure lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)