### PR TITLE
chore: add COLCON_IGNORE (shared ~/code single-tree workspace)

### DIFF
--- a/COLCON_IGNORE
+++ b/COLCON_IGNORE
@@ -1,0 +1,1 @@
+ROS1-only tree: colcon must skip it in the shared ~/code workspace (ROS1 is built with catkin ONLY — the marker is why colcon must not be used for ROS1). Remove when the ROS2 port / dual structure lands.


### PR DESCRIPTION
###### ClickUp Ticket Link
https://app.clickup.com/t/2157606/86cbe1paq

One-line marker for the single-tree migration (orchestra `sync ros2/migration` → flat `~/code` mounted into both ROS1 and ROS2 containers): colcon (= the ROS2 container) skips this repo; catkin ignores the file, so ROS1 builds are unaffected. Per team decision ROS1 is built with catkin only. Remove the marker when this repo's ROS2 port / dual structure lands.

Reopens the approach from the previously closed marker PR — the allowlist alternative was reverted in Navflex/robot_commissioning#22 (e1dfb99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)